### PR TITLE
initial prototype of non-caliper oriented bounding box method

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -126,3 +126,7 @@ harness = false
 [[bench]]
 name = "stitch"
 harness = false
+
+[[bench]]
+name = "minimum_rotated_rectangle"
+harness = false

--- a/geo/benches/minimum_rotated_rectangle.rs
+++ b/geo/benches/minimum_rotated_rectangle.rs
@@ -75,7 +75,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         .filter(|x|triangle.contains(x))
         .collect();
 
-        println!("{:?}",pts.len());
         bencher.iter(|| {
             criterion::black_box(oriented_bounding_box(&pts));
         });

--- a/geo/benches/minimum_rotated_rectangle.rs
+++ b/geo/benches/minimum_rotated_rectangle.rs
@@ -47,12 +47,12 @@ fn criterion_benchmark(c: &mut Criterion) {
        c.bench_function("rect filled  Triangle", |bencher| {
         let triangle = Triangle::new(
             coord!(x: 0., y: 0.),
-            coord!(x: 10., y: 0.),
-            coord!(x: 5., y: 10.),
+            coord!(x: 100., y: 0.),
+            coord!(x: 50., y: 100.),
         );
 
 
-        let pts = (0..1000).zip(0..1000)
+        let pts = (0..1000_00).zip(0..1000_00)
         .map(|(x,y)| {Point::new(x as f64 / 1000., y as f64/1000.)})
         .filter(|x|triangle.contains(x));
 
@@ -66,14 +66,16 @@ fn criterion_benchmark(c: &mut Criterion) {
      c.bench_function("obb filled Triangle", |bencher| {
          let triangle = Triangle::new(
             coord!(x: 0., y: 0.),
-            coord!(x: 10., y: 0.),
-            coord!(x: 5., y: 10.),
+            coord!(x: 100., y: 0.),
+            coord!(x: 50., y: 100.),
         );
 
-        let pts: Vec<geo::Coord> = (0..1000).zip(0..1000)
+        let pts: Vec<geo::Coord> = (0..1000_00).zip(0..1000_00)
         .map(|(x,y)| coord!{x:x as f64 / 1000., y: y as f64/1000.})
         .filter(|x|triangle.contains(x))
         .collect();
+
+        println!("{:?}",pts.len());
         bencher.iter(|| {
             criterion::black_box(oriented_bounding_box(&pts));
         });

--- a/geo/benches/minimum_rotated_rectangle.rs
+++ b/geo/benches/minimum_rotated_rectangle.rs
@@ -1,7 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use geo::Contains;
+use geo::Point;
 use geo::Polygon;
 use geo::MultiPoint;
-use geo::{coord,point};
+use geo::{coord,point,Triangle};
 
 use geo::algorithm::oriented_bounding_box;
 use geo::MinimumRotatedRect;
@@ -41,6 +43,42 @@ fn criterion_benchmark(c: &mut Criterion) {
             criterion::black_box(oriented_bounding_box(&pts));
         });
     });
+
+       c.bench_function("rect filled  Triangle", |bencher| {
+        let triangle = Triangle::new(
+            coord!(x: 0., y: 0.),
+            coord!(x: 10., y: 0.),
+            coord!(x: 5., y: 10.),
+        );
+
+
+        let pts = (0..1000).zip(0..1000)
+        .map(|(x,y)| {Point::new(x as f64 / 1000., y as f64/1000.)})
+        .filter(|x|triangle.contains(x));
+
+        let mp = MultiPoint::from_iter(pts);
+
+        bencher.iter(|| {
+            criterion::black_box(criterion::black_box(&mp).minimum_rotated_rect());
+        });
+    });
+
+     c.bench_function("obb filled Triangle", |bencher| {
+         let triangle = Triangle::new(
+            coord!(x: 0., y: 0.),
+            coord!(x: 10., y: 0.),
+            coord!(x: 5., y: 10.),
+        );
+
+        let pts: Vec<geo::Coord> = (0..1000).zip(0..1000)
+        .map(|(x,y)| coord!{x:x as f64 / 1000., y: y as f64/1000.})
+        .filter(|x|triangle.contains(x))
+        .collect();
+        bencher.iter(|| {
+            criterion::black_box(oriented_bounding_box(&pts));
+        });
+    });
+
 
 
 

--- a/geo/benches/minimum_rotated_rectangle.rs
+++ b/geo/benches/minimum_rotated_rectangle.rs
@@ -1,0 +1,50 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use geo::Polygon;
+use geo::MultiPoint;
+use geo::{coord,point};
+
+use geo::algorithm::oriented_bounding_box;
+use geo::MinimumRotatedRect;
+
+fn criterion_benchmark(c: &mut Criterion) {
+     c.bench_function("rect Norway", |bencher| {
+        let norway = geo_test_fixtures::norway_main::<f32>();
+        let polygon = Polygon::new(norway, vec![]);
+
+        bencher.iter(|| {
+            criterion::black_box(criterion::black_box(&polygon).minimum_rotated_rect());
+        });
+    });
+
+     c.bench_function("obb Norway", |bencher| {
+        let norway = geo_test_fixtures::norway_main::<f32>();
+        let polygon = Polygon::new(norway, vec![]);
+
+        bencher.iter(|| {
+            criterion::black_box(oriented_bounding_box(&polygon.exterior().0));
+        });
+    });
+
+    c.bench_function("rect Triangle", |bencher| {
+        let pts: Vec<geo::Point> = vec![point!{x:0.0,y:0.0},point!{x:0.0,y:1.0},point!{x:1.0,y:1.0}];
+        let mp = MultiPoint::new(pts);
+
+        bencher.iter(|| {
+            criterion::black_box(criterion::black_box(&mp).minimum_rotated_rect());
+        });
+    });
+
+     c.bench_function("obb Triangle", |bencher| {
+        let pts: Vec<geo::Coord> = vec![coord!{x:0.0,y:0.0},coord!{x:0.0,y:1.0},coord!{x:1.0,y:1.0}];
+
+        bencher.iter(|| {
+            criterion::black_box(oriented_bounding_box(&pts));
+        });
+    });
+
+
+
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -325,3 +325,6 @@ pub use rhumb::{RhumbBearing, RhumbDestination, RhumbDistance, RhumbIntermediate
 
 pub mod validation;
 pub use validation::Validation;
+
+pub mod obb;
+pub use obb::oriented_bounding_box;

--- a/geo/src/algorithm/obb.rs
+++ b/geo/src/algorithm/obb.rs
@@ -1,0 +1,170 @@
+
+use crate::{BoundingRect, Translate};
+use crate::{CoordFloat, GeoNum,GeoFloat};
+use crate::{Coord, MultiPoint, Point, Polygon,Rotate,LineString};
+
+/*
+https://logicatcore.github.io/scratchpad/lidar/sensor-fusion/jupyter/2021/04/20/2D-Oriented-Bounding-Box.html
+*/
+
+pub fn oriented_bounding_box<T>(points: &[Coord<T>]) -> Option<Polygon<T>>
+where T: CoordFloat + GeoNum + GeoFloat {
+
+    let l = points.len();
+
+    // handle trivial cases 
+    if l == 0 {
+        return None;
+    }
+    else if l == 1 {
+        return Some(Polygon::new(LineString::new(vec![
+            points[0],
+            points[0],
+            points[0],
+            points[0],
+            ]),vec![]));
+    }
+    else if l == 2 {
+         return Some(Polygon::new(LineString::new(vec![
+            points[0],
+            points[1],
+            points[1],
+            points[0],
+            ]),vec![]));
+    }
+    let mp: MultiPoint<T> = MultiPoint::from_iter(points.iter().map(|x|Point::new(x.x,x.y)));
+
+    let(meanx,meany) = mp.iter().fold((T::zero(),T::zero()),|acc,p|{
+        (acc.0 + p.x(),acc.1 + p.y())
+    });
+    let l = T::from(l).unwrap();
+    let meanx = meanx / l;
+    let meany = meany / l;
+
+    let data:Vec<[T;2]> = mp.iter().map(|p|[p.x(),p.y()]).collect();
+    let cov = calculate_2d_covariance_matrix(&data);
+    let evec = calculate_eigen_decomposition_col0(cov).unwrap();
+
+    let theta_pc1 = get_eigen_angle(evec[0],evec[1]).to_degrees();
+
+    let mp2 = mp
+        .translate(-meanx,-meany)
+        .rotate_around_point(-theta_pc1,Point::new(T::zero(),T::zero()));
+
+    let bbox: Polygon<T> = mp2.bounding_rect().unwrap().into();
+
+    let bbox: Polygon<T> = bbox.rotate_around_point(theta_pc1,Point::new(T::zero(),T::zero()));
+
+    let bbox = bbox.translate(meanx, meany);
+
+    Some(bbox)
+}
+
+
+fn get_eigen_angle<T>(v0:T,v1:T) -> T where T:CoordFloat{
+    (v0/v1).atan()
+}
+
+
+
+fn calculate_2d_covariance_matrix<T>(data: &Vec<[T; 2]>) -> [[T; 2]; 2] where T: CoordFloat{
+
+    let n = data.len();
+    
+    // Calculate means
+    let mut mean_x = T::zero();
+    let mut mean_y = T::zero();
+    
+    for point in data {
+        mean_x = mean_x + point[0];
+        mean_y = mean_y + point[1];
+    }
+    mean_x = mean_x / T::from(n).unwrap();
+    mean_y = mean_y / T::from(n).unwrap();
+
+    // Calculate covariances
+    let mut cov_xx = T::zero();
+    let mut cov_xy = T::zero();
+    let mut cov_yy = T::zero();
+
+    for point in data {
+        let diff_x = point[0] - mean_x;
+        let diff_y = point[1] - mean_y;
+        
+        cov_xx = cov_xx + diff_x * diff_x;
+        cov_xy = cov_xy + diff_x * diff_y;
+        cov_yy = cov_yy + diff_y * diff_y;
+    }
+
+    let n_minus_1 = T::from(n - 1).unwrap();
+    let covariance = [
+        [cov_xx / n_minus_1, cov_xy / n_minus_1],
+        [cov_xy / n_minus_1, cov_yy / n_minus_1]
+    ];
+
+    covariance
+}
+
+
+fn calculate_eigen_decomposition_col0<T>(matrix: [[T; 2]; 2]) -> Option<([T; 2])> where T:CoordFloat {
+    // For a 2x2 matrix [[a, b], [c, d]]
+    let a = matrix[0][0];
+    let b = matrix[0][1];
+    let c = matrix[1][0];
+    let d = matrix[1][1];
+
+    // Calculate coefficients of characteristic equation: λ² - (a+d)λ + (ad-bc) = 0
+    let trace = a + d;
+    let determinant = a * d - b * c;
+
+    // Calculate eigenvalues using quadratic formula: λ = (trace ± √(trace² - 4*determinant))/2
+    let discriminant = trace * trace - T::from(4.0).unwrap() * determinant;
+    
+    if discriminant < T::zero() {
+        return None; // Complex eigenvalues
+    }
+
+    let sqrt_discriminant = discriminant.sqrt();
+    let lambda1 = (trace + sqrt_discriminant) / T::from(2.0).unwrap();
+
+    // Calculate eigenvector col 0 only because we only use this
+    // For each eigenvalue λ, solve (A - λI)v = 0
+
+    // First eigenvector
+    if b != T::zero() {
+        let v1 = [b, lambda1 - a];
+        let norm = (v1[0] * v1[0] + v1[1] * v1[1]).sqrt();
+        Some( [v1[0] / norm, v1[1] / norm])
+    } else if (a - lambda1).abs() > (c).abs() {
+        Some([T::from(1.0).unwrap(),T::zero()])
+    } else {
+        Some([T::zero(), T::from(1.0).unwrap()])
+    }
+
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{MultiPoint,point};
+    use crate::MinimumRotatedRect;
+    #[test]
+    fn test() {
+        let mp: MultiPoint<f64> = MultiPoint::new(vec![
+            point!{x:0.0,y:0.0},
+            point!{x:0.0,y:1.0},
+            point!{x:1.0,y:1.0},
+            ]);
+
+
+        
+        let bbox = oriented_bounding_box(&mp.0.iter().map(|x|x.0).collect::<Vec<Coord<f64>>>());
+        let rect = mp.minimum_rotated_rect();
+
+        assert_eq!(bbox,rect);
+
+    }
+
+
+}

--- a/geo/src/algorithm/obb.rs
+++ b/geo/src/algorithm/obb.rs
@@ -106,7 +106,7 @@ fn calculate_2d_covariance_matrix<T>(data: &Vec<[T; 2]>) -> [[T; 2]; 2] where T:
 }
 
 
-fn calculate_eigen_decomposition_col0<T>(matrix: [[T; 2]; 2]) -> Option<([T; 2])> where T:CoordFloat {
+fn calculate_eigen_decomposition_col0<T>(matrix: [[T; 2]; 2]) -> Option<[T; 2]> where T:CoordFloat {
     // For a 2x2 matrix [[a, b], [c, d]]
     let a = matrix[0][0];
     let b = matrix[0][1];


### PR DESCRIPTION
# provides an approximation based on PCA, not the actual obb

skips the hull finding step  

Benchmark on exterior of Norway fixture

```
rect Norway             time:   [104.08 µs 104.52 µs 105.01 µs]
                        change: [+0.7161% +1.5426% +2.3795%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

obb Norway              time:   [28.231 µs 29.345 µs 30.602 µs]
                        change: [+13.403% +16.310% +19.363%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

Benchmark simple triangle
```
rect Triangle           time:   [361.54 ns 364.93 ns 368.78 ns]
                        change: [+2.3375% +3.4986% +4.6834%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

obb Triangle            time:   [181.76 ns 182.81 ns 183.90 ns]
                        change: [+2.5679% +3.1635% +3.7409%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
```

Benchmark on filled  Triangle
66666 points in triangle
```
rect filled  Triangle   time:   [4.9981 ms 5.0208 ms 5.0459 ms]
                        change: [+1.6402% +2.1467% +2.6507%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

obb filled Triangle     time:   [257.24 µs 261.84 µs 266.38 µs]
                        change: [+1.8444% +3.7902% +5.8682%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```
