### PR TITLE
Intersects linestring

### DIFF
--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -10,6 +10,11 @@ where
     }
 }
 
+symmetric_intersects_impl!(Coord<T>, LineString<T>);
+symmetric_intersects_impl!(Coord<T>, MultiLineString<T>);
+
+symmetric_intersects_impl!(Coord<T>, Line<T>);
+
 // The other side of this is handled via a blanket impl.
 impl<T> Intersects<Point<T>> for Coord<T>
 where
@@ -19,3 +24,11 @@ where
         self == &rhs.0
     }
 }
+symmetric_intersects_impl!(Coord<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Coord<T>, Polygon<T>);
+symmetric_intersects_impl!(Coord<T>, MultiPolygon<T>);
+
+symmetric_intersects_impl!(Coord<T>, Rect<T>);
+
+symmetric_intersects_impl!(Coord<T>, Triangle<T>);

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -13,8 +13,9 @@ where
             && point_in_rect(*rhs, self.start, self.end)
     }
 }
-symmetric_intersects_impl!(Coord<T>, Line<T>);
-symmetric_intersects_impl!(Line<T>, Point<T>);
+
+symmetric_intersects_impl!(Line<T>, LineString<T>);
+symmetric_intersects_impl!(Line<T>, MultiLineString<T>);
 
 impl<T> Intersects<Line<T>> for Line<T>
 where
@@ -68,6 +69,14 @@ where
     }
 }
 
+symmetric_intersects_impl!(Line<T>, Point<T>);
+symmetric_intersects_impl!(Line<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Line<T>, Polygon<T>);
+symmetric_intersects_impl!(Line<T>, MultiPolygon<T>);
+
+symmetric_intersects_impl!(Line<T>, Rect<T>);
+
 impl<T> Intersects<Triangle<T>> for Line<T>
 where
     T: GeoNum,
@@ -76,4 +85,3 @@ where
         self.intersects(&rhs.to_polygon())
     }
 }
-symmetric_intersects_impl!(Triangle<T>, Line<T>);

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -2,20 +2,37 @@ use super::{has_disjoint_bboxes, Intersects};
 use crate::BoundingRect;
 use crate::*;
 
-// Blanket implementation using self.lines().any().
-impl<T, G> Intersects<G> for LineString<T>
-where
-    T: CoordNum,
-    Line<T>: Intersects<G>,
-    G: BoundingRect<T>,
-{
-    fn intersects(&self, geom: &G) -> bool {
-        if has_disjoint_bboxes(self, geom) {
-            return false;
+macro_rules! blanket_intersects_linestring {
+    ($t:ty) => {
+        impl<T> $crate::Intersects<$t> for LineString<T>
+        where
+            T: CoordNum,
+            Line<T>: Intersects<$t>,
+            $t: BoundingRect<T>,
+        {
+            fn intersects(&self, rhs: &$t) -> bool {
+                if has_disjoint_bboxes(self, rhs) {
+                return false;
+            }
+            self.lines().any(|l| l.intersects(rhs))
+            }
         }
-        self.lines().any(|l| l.intersects(geom))
-    }
+    };
 }
+
+blanket_intersects_linestring!(Coord<T>);
+blanket_intersects_linestring!(LineString<T>);
+blanket_intersects_linestring!(MultiLineString<T>);
+blanket_intersects_linestring!(Line<T>);
+blanket_intersects_linestring!(Point<T>);
+blanket_intersects_linestring!(MultiPoint<T>);
+blanket_intersects_linestring!(Polygon<T>);
+blanket_intersects_linestring!(MultiPolygon<T>);
+blanket_intersects_linestring!(Rect<T>);
+blanket_intersects_linestring!(Triangle<T>);
+blanket_intersects_linestring!(Geometry<T>);
+blanket_intersects_linestring!(GeometryCollection<T>);
+
 
 // Blanket implementation from LineString<T>
 impl<T, G> Intersects<G> for MultiLineString<T>

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -21,9 +21,7 @@ macro_rules! blanket_intersects_linestring {
 }
 
 blanket_intersects_linestring!(Coord<T>);
-blanket_intersects_linestring!(LineString<T>);
 blanket_intersects_linestring!(MultiLineString<T>);
-blanket_intersects_linestring!(Line<T>);
 blanket_intersects_linestring!(Point<T>);
 blanket_intersects_linestring!(MultiPoint<T>);
 blanket_intersects_linestring!(Polygon<T>);
@@ -33,18 +31,75 @@ blanket_intersects_linestring!(Triangle<T>);
 blanket_intersects_linestring!(Geometry<T>);
 blanket_intersects_linestring!(GeometryCollection<T>);
 
-
-// Blanket implementation from LineString<T>
-impl<T, G> Intersects<G> for MultiLineString<T>
+impl <T> Intersects<LineString<T>> for LineString<T>
 where
     T: CoordNum,
-    LineString<T>: Intersects<G>,
-    G: BoundingRect<T>,
+    Line<T>: Intersects<Line<T>>,
+    LineString<T>: BoundingRect<T>,
 {
-    fn intersects(&self, rhs: &G) -> bool {
+    fn intersects(&self, rhs: &LineString<T>) -> bool {
         if has_disjoint_bboxes(self, rhs) {
             return false;
         }
+        self.lines().any(|l| rhs.lines().any(|other| l.intersects(&other)))
+    }
+}
+
+
+impl <T> Intersects<Line<T>> for LineString<T>
+where
+    T: CoordNum,
+    Line<T>: Intersects<Line<T>>,
+    LineString<T>: BoundingRect<T>,
+{
+    fn intersects(&self, rhs: &Line<T>) -> bool {
+        if has_disjoint_bboxes(self, rhs) {
+            return false;
+        }
+        self.lines().any(|l| l.intersects(&rhs))
+    }
+}
+
+macro_rules! blanket_intersects_multilinestring {
+    ($t:ty) => {
+        impl<T> $crate::Intersects<$t> for MultiLineString<T>
+        where
+            T: CoordNum,
+            LineString<T>: Intersects<$t>,
+            $t: BoundingRect<T>,
+        {
+            fn intersects(&self, rhs: &$t) -> bool {
+                if has_disjoint_bboxes(self, rhs) {
+                return false;
+            }
         self.iter().any(|p| p.intersects(rhs))
+            }
+        }
+    };
+}
+
+blanket_intersects_multilinestring!(Coord<T>);
+symmetric_intersects_impl!(MultiLineString<T>, LineString<T>);
+blanket_intersects_multilinestring!(Line<T>);
+blanket_intersects_multilinestring!(Point<T>);
+blanket_intersects_multilinestring!(MultiPoint<T>);
+blanket_intersects_multilinestring!(Polygon<T>);
+blanket_intersects_multilinestring!(MultiPolygon<T>);
+blanket_intersects_multilinestring!(Rect<T>);
+blanket_intersects_multilinestring!(Triangle<T>);
+blanket_intersects_multilinestring!(Geometry<T>);
+blanket_intersects_multilinestring!(GeometryCollection<T>);
+
+impl <T> Intersects<MultiLineString<T>> for MultiLineString<T>
+where
+    T: CoordNum,
+    LineString<T>: Intersects<LineString<T>>,
+    LineString<T>: BoundingRect<T>,
+{
+    fn intersects(&self, rhs: &MultiLineString<T>) -> bool {
+        if has_disjoint_bboxes(self, rhs) {
+            return false;
+        }
+        self.iter().any(|l| rhs.iter().any(|other| l.intersects(&other)))
     }
 }

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -31,4 +31,3 @@ where
         self.iter().any(|p| p.intersects(rhs))
     }
 }
-

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -16,10 +16,6 @@ where
         self.lines().any(|l| l.intersects(geom))
     }
 }
-symmetric_intersects_impl!(Coord<T>, LineString<T>);
-symmetric_intersects_impl!(Line<T>, LineString<T>);
-symmetric_intersects_impl!(Rect<T>, LineString<T>);
-symmetric_intersects_impl!(Triangle<T>, LineString<T>);
 
 // Blanket implementation from LineString<T>
 impl<T, G> Intersects<G> for MultiLineString<T>
@@ -36,7 +32,3 @@ where
     }
 }
 
-symmetric_intersects_impl!(Point<T>, MultiLineString<T>);
-symmetric_intersects_impl!(Line<T>, MultiLineString<T>);
-symmetric_intersects_impl!(Rect<T>, MultiLineString<T>);
-symmetric_intersects_impl!(Triangle<T>, MultiLineString<T>);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -549,10 +549,13 @@ mod test {
 
     #[test]
     fn exhaustive_compile_test() {
-        use geo_types::{GeometryCollection, Triangle};
+        use geo_types::{GeometryCollection, Triangle,Coord};
+        let c = Coord{x:0., y:0.};
         let pt: Point = Point::new(0., 0.);
-        let ln: Line = Line::new((0., 0.), (1., 1.));
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
+        let multi_ls = MultiLineString::new(vec![ls.clone()]);
+        let ln: Line = Line::new((0., 0.), (1., 1.));
+
         let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
         let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });
         let tri = Triangle::new(
@@ -563,9 +566,22 @@ mod test {
         let geom = Geometry::Point(pt);
         let gc = GeometryCollection::new_from(vec![geom.clone()]);
         let multi_point = MultiPoint::new(vec![pt]);
-        let multi_ls = MultiLineString::new(vec![ls.clone()]);
         let multi_poly = MultiPolygon::new(vec![poly.clone()]);
 
+        let _ = c.intersects(&c);
+        let _ = c.intersects(&pt);
+        let _ = c.intersects(&ln);
+        let _ = c.intersects(&ls);
+        let _ = c.intersects(&poly);
+        let _ = c.intersects(&rect);
+        let _ = c.intersects(&tri);
+        let _ = c.intersects(&geom);
+        let _ = c.intersects(&gc);
+        let _ = c.intersects(&multi_point);
+        let _ = c.intersects(&multi_ls);
+        let _ = c.intersects(&multi_poly);
+
+        let _ = pt.intersects(&c);
         let _ = pt.intersects(&pt);
         let _ = pt.intersects(&ln);
         let _ = pt.intersects(&ls);
@@ -577,6 +593,8 @@ mod test {
         let _ = pt.intersects(&multi_point);
         let _ = pt.intersects(&multi_ls);
         let _ = pt.intersects(&multi_poly);
+
+        let _ = ln.intersects(&c);
         let _ = ln.intersects(&pt);
         let _ = ln.intersects(&ln);
         let _ = ln.intersects(&ls);
@@ -588,6 +606,8 @@ mod test {
         let _ = ln.intersects(&multi_point);
         let _ = ln.intersects(&multi_ls);
         let _ = ln.intersects(&multi_poly);
+
+        let _ = ls.intersects(&c);
         let _ = ls.intersects(&pt);
         let _ = ls.intersects(&ln);
         let _ = ls.intersects(&ls);
@@ -599,6 +619,8 @@ mod test {
         let _ = ls.intersects(&multi_point);
         let _ = ls.intersects(&multi_ls);
         let _ = ls.intersects(&multi_poly);
+
+        let _ = poly.intersects(&c);
         let _ = poly.intersects(&pt);
         let _ = poly.intersects(&ln);
         let _ = poly.intersects(&ls);
@@ -610,6 +632,8 @@ mod test {
         let _ = poly.intersects(&multi_point);
         let _ = poly.intersects(&multi_ls);
         let _ = poly.intersects(&multi_poly);
+
+        let _ = rect.intersects(&c);
         let _ = rect.intersects(&pt);
         let _ = rect.intersects(&ln);
         let _ = rect.intersects(&ls);
@@ -621,6 +645,8 @@ mod test {
         let _ = rect.intersects(&multi_point);
         let _ = rect.intersects(&multi_ls);
         let _ = rect.intersects(&multi_poly);
+
+        let _ = tri.intersects(&c);
         let _ = tri.intersects(&pt);
         let _ = tri.intersects(&ln);
         let _ = tri.intersects(&ls);
@@ -632,6 +658,8 @@ mod test {
         let _ = tri.intersects(&multi_point);
         let _ = tri.intersects(&multi_ls);
         let _ = tri.intersects(&multi_poly);
+
+        let _ = geom.intersects(&c);
         let _ = geom.intersects(&pt);
         let _ = geom.intersects(&ln);
         let _ = geom.intersects(&ls);
@@ -643,6 +671,8 @@ mod test {
         let _ = geom.intersects(&multi_point);
         let _ = geom.intersects(&multi_ls);
         let _ = geom.intersects(&multi_poly);
+
+        let _ = gc.intersects(&c);
         let _ = gc.intersects(&pt);
         let _ = gc.intersects(&ln);
         let _ = gc.intersects(&ls);
@@ -654,6 +684,8 @@ mod test {
         let _ = gc.intersects(&multi_point);
         let _ = gc.intersects(&multi_ls);
         let _ = gc.intersects(&multi_poly);
+
+        let _ = multi_point.intersects(&c);
         let _ = multi_point.intersects(&pt);
         let _ = multi_point.intersects(&ln);
         let _ = multi_point.intersects(&ls);
@@ -665,6 +697,8 @@ mod test {
         let _ = multi_point.intersects(&multi_point);
         let _ = multi_point.intersects(&multi_ls);
         let _ = multi_point.intersects(&multi_poly);
+
+        let _ = multi_ls.intersects(&c);
         let _ = multi_ls.intersects(&pt);
         let _ = multi_ls.intersects(&ln);
         let _ = multi_ls.intersects(&ls);
@@ -676,6 +710,8 @@ mod test {
         let _ = multi_ls.intersects(&multi_point);
         let _ = multi_ls.intersects(&multi_ls);
         let _ = multi_ls.intersects(&multi_poly);
+
+        let _ = multi_poly.intersects(&c);
         let _ = multi_poly.intersects(&pt);
         let _ = multi_poly.intersects(&ln);
         let _ = multi_poly.intersects(&ls);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -549,8 +549,8 @@ mod test {
 
     #[test]
     fn exhaustive_compile_test() {
-        use geo_types::{GeometryCollection, Triangle,Coord};
-        let c = Coord{x:0., y:0.};
+        use geo_types::{Coord, GeometryCollection, Triangle};
+        let c = Coord { x: 0., y: 0. };
         let pt: Point = Point::new(0., 0.);
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
         let multi_ls = MultiLineString::new(vec![ls.clone()]);

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -22,8 +22,3 @@ where
         self.iter().any(|p| p.intersects(rhs))
     }
 }
-
-symmetric_intersects_impl!(Coord<T>, MultiPoint<T>);
-symmetric_intersects_impl!(Line<T>, MultiPoint<T>);
-symmetric_intersects_impl!(Triangle<T>, MultiPoint<T>);
-symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>);

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -2,8 +2,8 @@ use super::{has_disjoint_bboxes, Intersects};
 use crate::coordinate_position::CoordPos;
 use crate::{BoundingRect, CoordinatePosition};
 use crate::{
-    Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
-    Triangle,MultiPoint
+    Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
+    Polygon, Rect, Triangle,
 };
 
 impl<T> Intersects<Coord<T>> for Polygon<T>
@@ -70,8 +70,7 @@ where
     }
 }
 
-// Implementations for MultiPolygon
-
+// Blanket implementation for MultiPolygon
 impl<G, T> Intersects<G> for MultiPolygon<T>
 where
     T: GeoNum,
@@ -85,7 +84,6 @@ where
         self.iter().any(|p| p.intersects(rhs))
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -3,7 +3,7 @@ use crate::coordinate_position::CoordPos;
 use crate::{BoundingRect, CoordinatePosition};
 use crate::{
     Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
-    Triangle,
+    Triangle,MultiPoint
 };
 
 impl<T> Intersects<Coord<T>> for Polygon<T>
@@ -14,8 +14,9 @@ where
         self.coordinate_position(p) != CoordPos::Outside
     }
 }
-symmetric_intersects_impl!(Coord<T>, Polygon<T>);
-symmetric_intersects_impl!(Polygon<T>, Point<T>);
+
+symmetric_intersects_impl!(Polygon<T>, LineString<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiLineString<T>);
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where
@@ -28,29 +29,9 @@ where
             || self.intersects(&line.end)
     }
 }
-symmetric_intersects_impl!(Line<T>, Polygon<T>);
-symmetric_intersects_impl!(Polygon<T>, LineString<T>);
-symmetric_intersects_impl!(Polygon<T>, MultiLineString<T>);
 
-impl<T> Intersects<Rect<T>> for Polygon<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rect: &Rect<T>) -> bool {
-        self.intersects(&rect.to_polygon())
-    }
-}
-symmetric_intersects_impl!(Rect<T>, Polygon<T>);
-
-impl<T> Intersects<Triangle<T>> for Polygon<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rect: &Triangle<T>) -> bool {
-        self.intersects(&rect.to_polygon())
-    }
-}
-symmetric_intersects_impl!(Triangle<T>, Polygon<T>);
+symmetric_intersects_impl!(Polygon<T>, Point<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>);
 
 impl<T> Intersects<Polygon<T>> for Polygon<T>
 where
@@ -66,6 +47,26 @@ where
             polygon.interiors().iter().any(|inner_line_string| self.intersects(inner_line_string)) ||
             // self is contained inside polygon
             polygon.intersects(self.exterior())
+    }
+}
+
+symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>);
+
+impl<T> Intersects<Rect<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rect: &Rect<T>) -> bool {
+        self.intersects(&rect.to_polygon())
+    }
+}
+
+impl<T> Intersects<Triangle<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rect: &Triangle<T>) -> bool {
+        self.intersects(&rect.to_polygon())
     }
 }
 
@@ -85,11 +86,6 @@ where
     }
 }
 
-symmetric_intersects_impl!(Point<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Line<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Triangle<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>);
 
 #[cfg(test)]
 mod tests {

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -12,9 +12,36 @@ where
             && rhs.y <= self.max().y
     }
 }
-symmetric_intersects_impl!(Coord<T>, Rect<T>);
+
+symmetric_intersects_impl!(Rect<T>, LineString<T>);
+symmetric_intersects_impl!(Rect<T>, MultiLineString<T>);
+
+// Same logic as Polygon<T>: Intersects<Line<T>>, but avoid
+// an allocation.
+impl<T> Intersects<Line<T>> for Rect<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rhs: &Line<T>) -> bool {
+        let lb = self.min();
+        let rt = self.max();
+        let lt = Coord::from((lb.x, rt.y));
+        let rb = Coord::from((rt.x, lb.y));
+        // If either rhs.{start,end} lies inside Rect, then true
+        self.intersects(&rhs.start)
+            || self.intersects(&rhs.end)
+            || Line::new(lt, rt).intersects(rhs)
+            || Line::new(rt, rb).intersects(rhs)
+            || Line::new(lb, rb).intersects(rhs)
+            || Line::new(lt, lb).intersects(rhs)
+    }
+}
+
 symmetric_intersects_impl!(Rect<T>, Point<T>);
 symmetric_intersects_impl!(Rect<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Rect<T>, Polygon<T>);
+symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>);
 
 impl<T> Intersects<Rect<T>> for Rect<T>
 where
@@ -41,27 +68,6 @@ where
     }
 }
 
-// Same logic as Polygon<T>: Intersects<Line<T>>, but avoid
-// an allocation.
-impl<T> Intersects<Line<T>> for Rect<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rhs: &Line<T>) -> bool {
-        let lb = self.min();
-        let rt = self.max();
-        let lt = Coord::from((lb.x, rt.y));
-        let rb = Coord::from((rt.x, lb.y));
-        // If either rhs.{start,end} lies inside Rect, then true
-        self.intersects(&rhs.start)
-            || self.intersects(&rhs.end)
-            || Line::new(lt, rt).intersects(rhs)
-            || Line::new(rt, rb).intersects(rhs)
-            || Line::new(lb, rb).intersects(rhs)
-            || Line::new(lt, lb).intersects(rhs)
-    }
-}
-symmetric_intersects_impl!(Line<T>, Rect<T>);
 
 impl<T> Intersects<Triangle<T>> for Rect<T>
 where
@@ -71,4 +77,3 @@ where
         self.intersects(&rhs.to_polygon())
     }
 }
-symmetric_intersects_impl!(Triangle<T>, Rect<T>);

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -68,7 +68,6 @@ where
     }
 }
 
-
 impl<T> Intersects<Triangle<T>> for Rect<T>
 where
     T: GeoNum,

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -39,8 +39,18 @@ where
     }
 }
 
-symmetric_intersects_impl!(Coord<T>, Triangle<T>);
+symmetric_intersects_impl!(Triangle<T>, LineString<T>);
+symmetric_intersects_impl!(Triangle<T>, MultiLineString<T>);
+
+symmetric_intersects_impl!(Triangle<T>, Line<T>);
+
 symmetric_intersects_impl!(Triangle<T>, Point<T>);
+symmetric_intersects_impl!(Triangle<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Triangle<T>, Polygon<T>);
+symmetric_intersects_impl!(Triangle<T>, MultiPolygon<T>);
+
+symmetric_intersects_impl!(Triangle<T>, Rect<T>);
 
 impl<T> Intersects<Triangle<T>> for Triangle<T>
 where
@@ -50,3 +60,4 @@ where
         self.to_polygon().intersects(&rhs.to_polygon())
     }
 }
+

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -60,4 +60,3 @@ where
         self.to_polygon().intersects(&rhs.to_polygon())
     }
 }
-


### PR DESCRIPTION
prototypes for skipping the recalculation of bounding box when recursively checking intersects

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
