### PR TITLE
remove extra check in linestring contains coord evaluation

### DIFF
--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,8 +1,7 @@
 use super::{Contains, impl_contains_from_relate, impl_contains_geometry_for};
-use crate::Orientation;
 use crate::algorithm::kernels::Kernel;
 use crate::geometry::*;
-use crate::{CoordNum, GeoFloat, GeoNum, HasDimensions};
+use crate::{CoordNum, GeoFloat, GeoNum, HasDimensions, Intersects, Orientation};
 
 // ┌────────────────────────────────┐
 // │ Implementations for LineString │
@@ -21,9 +20,9 @@ where
             return self.is_closed();
         }
 
-        self.lines()
-            .enumerate()
-            .any(|(i, line)| line.contains(coord) || (i > 0 && coord == &line.start))
+        // since it is already known that coord != linestring start or end
+        // it is sufficient to check if the coord intersects any line,
+        self.lines().any(|ln| ln.intersects(coord))
     }
 }
 


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
```
linestring contains point
                        time:   [5.2024 ns 5.2342 ns 5.2691 ns]
                        change: [-57.460% -56.904% -56.313%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe

linestring not contains point
                        time:   [4.8770 ns 4.9067 ns 4.9445 ns]
                        change: [-56.501% -55.919% -55.321%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe


```